### PR TITLE
Fix Remote Workspace unable to get clipboard data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -361,15 +361,6 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "copy-paste": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/copy-paste/-/copy-paste-1.3.0.tgz",
-            "integrity": "sha1-p+bEocKP3t8rCB5yuX3y75X0ce0=",
-            "requires": {
-                "iconv-lite": "^0.4.8",
-                "sync-exec": "~0.6.x"
-            }
-        },
         "cross-spawn": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
@@ -593,14 +584,6 @@
                         "ms": "^2.1.1"
                     }
                 }
-            }
-        },
-        "iconv-lite": {
-            "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "imurmurhash": {
@@ -1043,11 +1026,6 @@
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
-        "safer-buffer": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-        },
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1159,12 +1137,6 @@
             "requires": {
                 "has-flag": "^3.0.0"
             }
-        },
-        "sync-exec": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/sync-exec/-/sync-exec-0.6.2.tgz",
-            "integrity": "sha1-cX0izFPwzh3vVZQ2LzqJouu5EQU=",
-            "optional": true
         },
         "test-exclude": {
             "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -49,9 +49,7 @@
         "typescript": "^3.7.4",
         "vscode-test": "^1.3.0"
     },
-    "dependencies": {
-        "copy-paste": "^1.3.0"
-    },
+    "dependencies": {},
     "nyc": {
         "extension": [
             ".ts",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,9 @@ import {excelToMarkdown} from './excel-markdown-tables'
  * @param context
  */
 export function activate(context: vscode.ExtensionContext) {
-    var disposable = vscode.commands.registerCommand('extension.excelToMarkdown', () => {
-        let clipboard = require('copy-paste');
-
-        clipboard.paste(function(err, val) {
-            pasteText(val);
-        });
+    var disposable = vscode.commands.registerCommand('extension.excelToMarkdown', async () => {
+        const text = await vscode.env.clipboard.readText();
+        pasteText(text);
     });
 
     context.subscriptions.push(disposable);
@@ -37,7 +34,6 @@ export function deactivate() {
  * @param rawData The raw clipboard contents containing the excel table to convert
  */
 function pasteText(rawData: string) {
-    let clipboard = require('copy-paste');
 
     let paste = excelToMarkdown(rawData);
 


### PR DESCRIPTION
`copy-paste` reads data from the workspace's environment clipboard. If the workspace is Remote, such as using 'remote-ssh', 'copy-paste' reads the Remote host's clipboard instead of the user's local clipboard, and it gets nothing.So instead of `copy-paste` I used `vscode clipboard API`, which always takes data from the user's local clipboard.