### PR TITLE
fix: escape pipe with backslash

### DIFF
--- a/src/excel-markdown-tables.ts
+++ b/src/excel-markdown-tables.ts
@@ -10,7 +10,13 @@ export function excelToMarkdown(rawData: string): string {
     let data = rawData.trim();
     var intraCellNewlineReplacedData = helper.replaceIntraCellNewline(data)
     var rows = helper.splitIntoRowsAndColumns(intraCellNewlineReplacedData);
-    var {columnWidths, colAlignments } = helper.getColumnWidthsAndAlignments(rows);
+    rows = rows.map(function (row, index) {
+        return row.map(function (column, index) {
+            const res = column.replace(/\|/g, '\\|');
+            return res;
+        });
+    })
+    var { columnWidths, colAlignments } = helper.getColumnWidthsAndAlignments(rows);
     const markdownRows = helper.addMarkdownSyntax(rows, columnWidths);
 
     return helper.addAlignmentSyntax(markdownRows, columnWidths, colAlignments).join(LINE_ENDING);


### PR DESCRIPTION
when paste from excel, if the content contains pipe (|), it will conflict with markdown column separator, so we need to escape it